### PR TITLE
Add digital multimeter interface + HP instrument class

### DIFF
--- a/photonmover/Interfaces/DigitalMultimeter.py
+++ b/photonmover/Interfaces/DigitalMultimeter.py
@@ -1,0 +1,31 @@
+# This is an interface that any instrument that can
+# be used as a digital multimeter can implement
+
+from abc import ABC, abstractmethod
+# ABC means Abstract Base Class and is basically an interface
+
+
+class DigitalMultimeter(ABC):
+
+    def __init__(self):
+        super().__init__()
+
+    @abstractmethod
+    def initialize(self):
+        """
+        Initializes the instrument 
+        """
+        pass 
+
+
+    @abstractmethod
+    def get_voltage(self, voltage):
+        """
+        Sets the voltage to the specified value (in V)
+        :return:
+        """
+        pass
+    
+
+    def get_id(self):
+        return ("DigitalMultimeter")

--- a/photonmover/Interfaces/DigitalMultimeter.py
+++ b/photonmover/Interfaces/DigitalMultimeter.py
@@ -2,21 +2,18 @@
 # be used as a digital multimeter can implement
 
 from abc import ABC, abstractmethod
-# ABC means Abstract Base Class and is basically an interface
 
 
 class DigitalMultimeter(ABC):
-
     def __init__(self):
         super().__init__()
 
     @abstractmethod
     def initialize(self):
         """
-        Initializes the instrument 
+        Initializes the instrument
         """
-        pass 
-
+        pass
 
     @abstractmethod
     def get_voltage(self, voltage):
@@ -25,7 +22,7 @@ class DigitalMultimeter(ABC):
         :return:
         """
         pass
-    
 
+    @abstractmethod
     def get_id(self):
-        return ("DigitalMultimeter")
+        return "DigitalMultimeter"

--- a/photonmover/instruments/digital_multimeters/Agilent34401A.py
+++ b/photonmover/instruments/digital_multimeters/Agilent34401A.py
@@ -1,70 +1,66 @@
-import sys
-import time
 import pyvisa as visa
 from photonmover.Interfaces.DigitalMultimeter import DigitalMultimeter
 from photonmover.Interfaces.Instrument import Instrument
 
 
-class Agilent34401A(Instrument,DigitalMultimeter):
+class Agilent34401A(Instrument, DigitalMultimeter):
     """
-    Code for controlling Agilent 34401A-type digital multimeters. 
+    Code for controlling Agilent 34401A-type digital multimeters.
     """
 
     def __init__(
-            self,
-            gpib_address = "GPIB1::4::INSTR",
-        ):
+        self,
+        gpib_address="GPIB1::4::INSTR",
+    ):
         super().__init__()
 
         self.gpib_address = gpib_address
         self.instr = None
 
-
     def initialize(self):
         """
-        Initializes the instrumen t
+        Initializes the instrument
         :return:
         """
-        print('Opening connnection to Agilent DMM')
+        print("Opening connnection to Agilent DMM")
 
         rm = visa.ResourceManager()
         try:
             self.instr = rm.open_resource(
-                self.gpib_address, timeout=6000)  # 2 min timeout
-            print('Connected to Agilent DMM')
+                self.gpib_address, timeout=6000
+            )  # 2 min timeout
+            print("Connected to Agilent DMM")
         except BaseException:
-            raise ValueError('Cannot connect to the Agilent DMM')
-        
+            raise ValueError("Cannot connect to the Agilent DMM")
+
     def close(self):
-        print('Disconnecting Agilent DMM')
+        print("Disconnecting Agilent DMM")
         self.instr.close()
-    
+
     def identify(self):
         """
         Identify the instrument
         """
         return self.instr.query("*IDN?")
-    
-    def configure_measurement(self, range=5 ):
-        
+
+    def configure_measurement(self, range=5):
         # use maximum resolution
         self.instr.write("VOLTage:DC:NPLCycles 100")
         self.instr.write("CONFigure:VOLTage:DC {:f}, MAX".format(range))
 
-
     def get_voltage(self):
-        """ 
+        """
         Queries the current voltage.
 
         """
 
         self.instr.write("READ?")
-        volt = float( self.instr.read().strip("\n"))
+        volt = float(self.instr.read().strip("\n"))
 
         return volt
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     dmm = Agilent34401A()
     dmm.initialize()
     dmm.identify()

--- a/photonmover/instruments/digital_multimeters/Agilent34401A.py
+++ b/photonmover/instruments/digital_multimeters/Agilent34401A.py
@@ -1,0 +1,71 @@
+import sys
+import time
+import pyvisa as visa
+from photonmover.Interfaces.DigitalMultimeter import DigitalMultimeter
+from photonmover.Interfaces.Instrument import Instrument
+
+
+class Agilent34401A(Instrument,DigitalMultimeter):
+    """
+    Code for controlling Agilent 34401A-type digital multimeters. 
+    """
+
+    def __init__(
+            self,
+            gpib_address = "GPIB1::4::INSTR",
+        ):
+        super().__init__()
+
+        self.gpib_address = gpib_address
+        self.instr = None
+
+
+    def initialize(self):
+        """
+        Initializes the instrumen t
+        :return:
+        """
+        print('Opening connnection to Agilent DMM')
+
+        rm = visa.ResourceManager()
+        try:
+            self.instr = rm.open_resource(
+                self.gpib_address, timeout=6000)  # 2 min timeout
+            print('Connected to Agilent DMM')
+        except BaseException:
+            raise ValueError('Cannot connect to the Agilent DMM')
+        
+    def close(self):
+        print('Disconnecting Agilent DMM')
+        self.instr.close()
+    
+    def identify(self):
+        """
+        Identify the instrument
+        """
+        return self.instr.query("*IDN?")
+    
+    def configure_measurement(self, range=5 ):
+        
+        # use maximum resolution
+        self.instr.write("VOLTage:DC:NPLCycles 100")
+        self.instr.write("CONFigure:VOLTage:DC {:f}, MAX".format(range))
+
+
+    def get_voltage(self):
+        """ 
+        Queries the current voltage.
+
+        """
+
+        self.instr.write("READ?")
+        volt = float( self.instr.read().strip("\n"))
+
+        return volt
+
+
+if __name__ == '__main__':
+    dmm = Agilent34401A()
+    dmm.initialize()
+    dmm.identify()
+    dmm.close()


### PR DESCRIPTION
This PR introduces a very simple class for interfacing with HP 6 1/2-digit benchtop digital multimeters. 

The functionality is sparse but provides a good starting point for a larger interface. 